### PR TITLE
windows has different columns names for account and contact

### DIFF
--- a/src/db/query.js
+++ b/src/db/query.js
@@ -56,6 +56,7 @@ function query(query, db = null) {
                             column === 'account' ||
                             column === 'eventJSON' ||
                             column === 'contact' ||
+                            column === 'Json' ||
                             column === 'user'
                         ) {
                             let o = JSON.parse(res[j])


### PR DESCRIPTION
in ios, account's and contact's extrafield columns are account & contact, but in windows both are Json

There are also JsonUntouched columns but I believe they are same