### PR TITLE
use a slot for keywords container

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -537,6 +537,7 @@ Custom Card component for files
 | slot | description | props
 | :--- | :--- | :--- |
 | `items` | slot to replace file options menu items. As long is this is a dropdown menu, you must to follow dropdown menu items structure. Check usage example to see how it's used.
+| `keywords` | slot to replace file keywords container, at the bottom of the file card. Here keywords can be show in a different style, only some keywords can be shown etc.
 
 #### Available events
 | event | description |

--- a/src/components/FileCard/FileCard.vue
+++ b/src/components/FileCard/FileCard.vue
@@ -50,7 +50,10 @@
         <!-- File name -->
         <div class="file-card__file-name">{{ body }}</div>
         <!-- Keywords -->
-        <div v-if="keywords.length > 0" class="mt-1">
+        <div v-if="hasKeywordsSlot" class="mt-1">
+            <slot name="keywords" />
+        </div>
+        <div v-else-if="keywords.length > 0" class="mt-1">
             <span class="ui text small file-card__keywords">
                 {{ keywords }}
             </span>
@@ -120,7 +123,8 @@ export default defineComponent({
     setup(props, { slots, emit }) {
         const state = reactive({
             optionsExpanded: false,
-            hasItemsSlot: !!slots.items
+            hasItemsSlot: !!slots.items,
+            hasKeywordsSlot: !!slots.keywords
         })
 
         const styles = computed(() => ({


### PR DESCRIPTION
Use a slot for keywords if given.
In some cases customer may want keywords with different style, ignore some keywords, etc.