### PR TITLE
Read only all ObjectForm feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [UNRELEASED]
 
+## 1.4.11
+### Changed
+- Added capability to make all fields read-only in ObjectForm
+- Updated docs
+
 ## 1.4.10
 ### Changed
 - Added "Load more" feature into FilterDropdown component

--- a/src/components/ObjectForm.vue
+++ b/src/components/ObjectForm.vue
@@ -119,6 +119,10 @@ export default {
         ignoreExternalIdValidation: {
             type: Boolean,
             default: false
+        },
+        allFieldsReadOnly: {
+            type: Boolean,
+            default: false
         }
     },
 
@@ -254,7 +258,7 @@ export default {
                                     if (props.customSettings.includes[f.name]) {
                                         f.settings = props.customSettings[f.name]
                                     }
-                                    if (props.readOnlyFields.includes(f.name)) {
+                                    if (fieldShouldBeReadOnly(f)) {
                                         f.updateable = false
                                     } else if (props.customReferences && props.customReferences[f.name]) {
                                         f.loadExternalReferences(props.customReferences[f.name])
@@ -316,7 +320,7 @@ export default {
                                                         if (props.customSettings[field.name]) {
                                                             field.settings = props.customSettings[field.name]
                                                         }
-                                                        if (props.readOnlyFields.includes(field.name)) {
+                                                        if (fieldShouldBeReadOnly(field)) {
                                                             field.updateable = false
                                                         } else if (
                                                             props.customReferences &&
@@ -361,7 +365,7 @@ export default {
                                     console.warn('removed field')
                                     continue
                                 }
-                                if (props.readOnlyFields.includes(f.name)) {
+                                if (fieldShouldBeReadOnly(f)) {
                                     f.updateable = false
                                 }
                                 if (f.nillable && f.name !== 'Name') {
@@ -506,7 +510,7 @@ export default {
         }
 
         const emitUpdate = () => {
-            //console.log('update', state.obj)
+            // console.log('update', state.obj)
             attrs.emit('input', state.obj)
         }
 
@@ -522,6 +526,10 @@ export default {
                 }
             }
             return ''
+        }
+
+        const fieldShouldBeReadOnly = field => {
+            return props.readOnlyFields.includes(field.name) || props.allFieldsReadOnly
         }
 
         return {

--- a/stories/components/ObjectForm.stories.mdx
+++ b/stories/components/ObjectForm.stories.mdx
@@ -7,14 +7,20 @@ import { Meta, Story, ArgsTable, Preview } from '@storybook/addon-docs/blocks';
 Displays a salesforce object as a form, uses layouts if available otherwise uses schemas. Layouts are supported by android at the moment only.
 
 ### Properties:
-- objectType(require: true, type: String)
-- fields(type: Array, strings, which fields to display in the form, default displays all fields from schema)
-- excludeFields(type: Array, strings, which fields to exclude),
-- hasSave(type: Boolean, if save button is displayed or not)
-- id(type: String, id of existing object for form fill up)
+- objectType (require: true, type: String)
+- fields (type: Array, strings, which fields to display in the form, default displays all fields from schema)
+- excludeFields (type: Array, strings, which fields to exclude)
+- readOnlyFields (type: Array, strings, which fields to set as read-only)
+- customReferences (type: Object)
+- customSettings (type: Object)
+- hideHelpText (type: Boolean)
+- hasSave (type: Boolean, if save button is displayed or not)
+- id (type: String, id of existing object for form fill up)
 - recordType (type: String, record type to use for form)
-- obj(type: Object, object to use for form)
-- onSave(type: Function, callback on form save)
+- value (type: Object)
+- onSave (type: Function, callback on form save)
+- ignoreExternalIdValidation (type: Boolean)
+- allFieldsReadOnly (type: Boolean, set all fields read-only regardless of whether they are included in readOnlyFields Array)
 
 ### Methods:
 - save


### PR DESCRIPTION
Added capability to make all fields read-only in ObjectForm using an `allFieldsReadOnly` prop.