### PR TITLE
Fix breaking change on sass loader 11

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "prettier": "^1.19.1",
     "rimraf": "^3.0.2",
     "sass": "^1.26.3",
-    "sass-loader": "^11.0.1",
+    "sass-loader": "^10.1.1",
     "vue": "^2.6.12",
     "vue-template-compiler": "^2.6.12"
   },

--- a/stories/docs/sdk-install.stories.mdx
+++ b/stories/docs/sdk-install.stories.mdx
@@ -13,10 +13,11 @@ On your project, be sure that you have these dependencies installed
 - "sass": "^1.26.3" (devDependency)
 - "sass-loader": "^8.0.2" (devDependency)
 ```
-  
+
  If you only miss SASS run
  ```bash
- npm install -D sass sass-loader
+ # sass-loader@11 only allows webpack >= 5
+ npm install -D sass sass-loader@10
  ```
 
 ## Installation


### PR DESCRIPTION
### :book: Description
Downgrades `sass-loader` to a compatible version with `webpack@4`. Also updates the `sdk-install` story.