### PR TITLE
fix: preselct single picklist value in controlled dropdown

### DIFF
--- a/src/components/ObjectForm.vue
+++ b/src/components/ObjectForm.vue
@@ -449,6 +449,8 @@ export default {
                     // to check whether each dependent value is valid
                     return !!(bitmap.charCodeAt(index >> 3) & (128 >> index % 8))
                   })
+
+                  if (field.filteredValues.length === 1) Vue.set(state.obj, field.name, field.filteredValues[0].value)
                 }
               },
               {


### PR DESCRIPTION
### Issue link
no link

### 📖  Description
If dropdown got only one picklist value and it's controlled by another form field, preselect that value

- [x] Tested on Windows
- [x]  Tested on iOS

### 📷  Screenshots

no screenshots
