### PR TITLE
feat: generate chapters for custom decks when parsing presentations (PLA-761)

### DIFF
--- a/src/instance/stores/files.store.js
+++ b/src/instance/stores/files.store.js
@@ -268,7 +268,7 @@ async function generateCustomDeckChapters(presentations) {
 
       const chaptersByDeckId = await Promise.all(
         Array.from(usedDecksIds.values()).map((deckId) =>
-          fetch(`../slides/${deckId}/chapters.json`)
+          fetch(`${window.documentPath}/slides/${deckId}/chapters.json`)
             .then((r) => r.json())
             .catch(() => null)
             .then((data) => [deckId, data.chapters])
@@ -281,7 +281,7 @@ async function generateCustomDeckChapters(presentations) {
         slide.chapterName = foundChapter ? foundChapter.nameV : null
       })
 
-      deck.setupJSON = await fetch(`../slides/${parsedSlides[0].deckId}/setup.json`)
+      deck.setupJSON = await fetch(`${window.documentPath}/slides/${parsedSlides[0].deckId}/setup.json`)
         .then((r) => r.json())
         .catch(() => null)
 

--- a/src/instance/stores/files.store.js
+++ b/src/instance/stores/files.store.js
@@ -5,6 +5,11 @@ import { createStore } from '../../store'
 import { fireEvent } from '../../event'
 import { joinPath } from '../../utils'
 
+// fetch polyfill
+if (!window.fetch) {
+  import(/* webpackChunkName: "polyfill-fetch" */ 'whatwg-fetch')
+}
+
 class FilesStore {
   id = 'filesStore'
   oneTimeLoadPresentations = false

--- a/src/instance/stores/files.store.js
+++ b/src/instance/stores/files.store.js
@@ -230,7 +230,7 @@ function getChapterForSlideIndex(chapters, slideIndex) {
   return null
 }
 
-async function generateChapters(presentations) {
+async function generateCustomDeckChapters(presentations) {
   // eslint-disable-next-line no-async-promise-executor
   return new Promise(async (resolve) => {
     for (const key in presentations) {
@@ -326,7 +326,7 @@ window.loadPresentations = function(presentationsObject) {
     presentations = JSON.parse(presentations)
   }
 
-  generateChapters(presentationsObject).then(() => {
+  generateCustomDeckChapters(presentationsObject).then(() => {
     window.presentationsObject = presentations
 
     if (window.presentationsObject) {

--- a/src/instance/stores/files.store.js
+++ b/src/instance/stores/files.store.js
@@ -291,6 +291,7 @@ async function generateCustomDeckChapters(presentations) {
             const lastAddedChapter = chapters[chapters.length - 1]
 
             if (!currentSlide.chapterName) {
+              // Required to signal a gap between chapters
               chapters.push(null)
             } else if (
               lastAddedChapter &&

--- a/src/instance/stores/files.store.js
+++ b/src/instance/stores/files.store.js
@@ -217,6 +217,7 @@ window.getAllowedIDs = function() {
   return store.state.allowedIDs
 }
 
+// Generation of Chapters
 function getChapterForSlideIndex(chapters, slideIndex) {
   for (let i = 0; i < chapters.length; i++) {
     const chapter = chapters[i]
@@ -227,6 +228,95 @@ function getChapterForSlideIndex(chapters, slideIndex) {
   }
 
   return null
+}
+
+async function generateChapters(presentations) {
+  // eslint-disable-next-line no-async-promise-executor
+  return new Promise(async (resolve) => {
+    for (const key in presentations) {
+      const deck = presentations[key]
+
+      if (!deck.isCustom) {
+        continue
+      }
+
+      const parsedSlides = deck.slideOrder
+        ? deck.slideOrder.split(',').map((slide) => {
+            const [deckId, index] = slide.split('|')
+
+            return {
+              deckId,
+              index: parseInt(index) - 1,
+            }
+          })
+        : []
+
+      if (parsedSlides.length === 0) {
+        continue
+      }
+
+      const usedDecksIds = parsedSlides.reduce((accumulator, slide) => {
+        accumulator.add(slide.deckId)
+
+        return accumulator
+      }, new Set())
+
+      const chaptersByDeckId = await Promise.all(
+        Array.from(usedDecksIds.values()).map((deckId) =>
+          fetch(`../slides/${deckId}/chapters.json`)
+            .then((r) => r.json())
+            .catch(() => null)
+            .then((data) => [deckId, data.chapters])
+        )
+      ).then((decksChapters) => new Map(decksChapters))
+
+      parsedSlides.forEach((slide) => {
+        const foundChapter = getChapterForSlideIndex(chaptersByDeckId.get(slide.deckId), slide.index)
+
+        slide.chapterName = foundChapter ? foundChapter.nameV : null
+      })
+
+      // TODO: what if setup of the first deck doesn't have chapter navigation?
+      // we maybe need a hardcoded default or we need to make sure to add the chapters bar there if needed
+      // if setup is empty, read from settings hardcoded
+      deck.setupJSON = await fetch(`../slides/${parsedSlides[0].deckId}/setup.json`)
+        .then((r) => r.json())
+        .catch(() => null)
+
+      deck.chapters = {
+        chapters: parsedSlides
+          .reduce((chapters, currentSlide, currentSlideIndex) => {
+            const lastAddedChapter = chapters[chapters.length - 1]
+
+            if (!currentSlide.chapterName) {
+              chapters.push(null)
+            } else if (
+              lastAddedChapter &&
+              currentSlide.chapterName === lastAddedChapter.nameV &&
+              currentSlide.deckId === lastAddedChapter.deckId
+            ) {
+              lastAddedChapter.endIndex = currentSlideIndex
+            } else {
+              chapters.push({
+                nameV: currentSlide.chapterName,
+                deckId: currentSlide.deckId,
+                startIndex: currentSlideIndex === 0 ? 0 : currentSlideIndex - 1,
+                endIndex: currentSlideIndex,
+              })
+            }
+
+            return chapters
+          }, [])
+          .filter((ch) => ch !== null)
+          .map(({ nameV, startIndex, endIndex }) => ({ nameV, startIndex, endIndex })),
+      }
+
+      fireEvent('saveFromHTML', { id: deck.ID, variables: deck })
+    }
+
+    // resolve when all completed
+    resolve()
+  })
 }
 window.loadPresentations = function(presentationsObject) {
   if (typeof presentationsObject === 'string') {

--- a/src/instance/stores/files.store.js
+++ b/src/instance/stores/files.store.js
@@ -318,17 +318,23 @@ async function generateChapters(presentations) {
     resolve()
   })
 }
-window.loadPresentations = function(presentationsObject) {
-  if (typeof presentationsObject === 'string') {
-    // eslint-disable-next-line no-param-reassign
-    presentationsObject = JSON.parse(presentationsObject)
-  }
-  window.presentationsObject = presentationsObject
-  if (window.presentationsObject) {
-    const store = useFilesStore()
 
-    store.parsePresentations(window.presentationsObject)
+window.loadPresentations = function(presentationsObject) {
+  let presentations = presentationsObject
+
+  if (typeof presentationsObject === 'string') {
+    presentations = JSON.parse(presentations)
   }
+
+  generateChapters(presentationsObject).then(() => {
+    window.presentationsObject = presentations
+
+    if (window.presentationsObject) {
+      const store = useFilesStore()
+
+      store.parsePresentations(window.presentationsObject)
+    }
+  })
 }
 
 window.filterJSON = function(allowedIDsV) {

--- a/src/instance/stores/files.store.js
+++ b/src/instance/stores/files.store.js
@@ -217,6 +217,17 @@ window.getAllowedIDs = function() {
   return store.state.allowedIDs
 }
 
+function getChapterForSlideIndex(chapters, slideIndex) {
+  for (let i = 0; i < chapters.length; i++) {
+    const chapter = chapters[i]
+
+    if (slideIndex >= chapter.startIndex && slideIndex < chapter.endIndex) {
+      return chapter
+    }
+  }
+
+  return null
+}
 window.loadPresentations = function(presentationsObject) {
   if (typeof presentationsObject === 'string') {
     // eslint-disable-next-line no-param-reassign

--- a/src/instance/stores/files.store.js
+++ b/src/instance/stores/files.store.js
@@ -276,9 +276,6 @@ async function generateCustomDeckChapters(presentations) {
         slide.chapterName = foundChapter ? foundChapter.nameV : null
       })
 
-      // TODO: what if setup of the first deck doesn't have chapter navigation?
-      // we maybe need a hardcoded default or we need to make sure to add the chapters bar there if needed
-      // if setup is empty, read from settings hardcoded
       deck.setupJSON = await fetch(`../slides/${parsedSlides[0].deckId}/setup.json`)
         .then((r) => r.json())
         .catch(() => null)


### PR DESCRIPTION
### Issue link
https://pitcher-ag.atlassian.net/browse/PLA-761

### 📖  Description
- Chapters are now being generated and shown in custom deck items
- ~~Needs edge cases to be checked. See `TODO` @wojtiku added~~ (Mert checked, couldn't find any)
- Needs to be tested on Windows (awaiting update from cagri)
- ~~Needs to be added to `pitcher-js-platform`~~ Done

- [ ] Tested on Windows

### 📷  Screenshots
![Screenshot 2021-04-23 at 16 06 51](https://user-images.githubusercontent.com/10902780/115883419-0a2c1e80-a44e-11eb-85e9-262bd845049b.png)
![Screenshot 2021-04-23 at 16 07 01](https://user-images.githubusercontent.com/10902780/115883441-1021ff80-a44e-11eb-8d1b-d06317460943.png)
![Screenshot 2021-04-23 at 16 07 32](https://user-images.githubusercontent.com/10902780/115883445-11ebc300-a44e-11eb-9f0a-671736d184be.png)

