### PR TITLE
fix: filter dropdown return emits

### DIFF
--- a/src/components/FilterDropdown.vue
+++ b/src/components/FilterDropdown.vue
@@ -397,9 +397,11 @@ export default {
       // select
       if (!isSelected(item)) {
         if (props.returnType === 'object') {
-          emit('input', props.value.concat([item]))
+          // eslint-disable-next-line consistent-return
+          return emit('input', props.value.concat([item]))
         } else {
-          emit('input', props.value.concat([item[props.returnType]]))
+          // eslint-disable-next-line consistent-return
+          return emit('input', props.value.concat([item[props.returnType]]))
         }
       }
 


### PR DESCRIPTION
### Issue link
None

### 📖  Description
Revert linter removed returns, causes filterdropdown not to work properly

- [ ] Tested on Windows