### PR TITLE
fix: dropdown - use unique id for list items, fix styling issue

### DIFF
--- a/src/components/Dropdown.vue
+++ b/src/components/Dropdown.vue
@@ -63,8 +63,8 @@
       <!-- menu items -->
       <div class="menu">
         <div
-          v-for="(item, index) in listItems"
-          :key="index"
+          v-for="item in listItems"
+          :key="item.uuid"
           :data-value="item.value"
           :data-text="item.text"
           :class="[item.type, { disabled: item.disabled, 'active filtered': value && value.includes(item.value) }]"
@@ -82,6 +82,7 @@
 <script>
 /* eslint-disable vue/require-prop-types, vue/no-unused-properties */
 import { computed, onMounted, reactive, toRefs } from '@vue/composition-api'
+import { makeId } from '../db/externalID'
 import { parsePxStyle, validateSize } from './mixins'
 
 export default {
@@ -229,6 +230,7 @@ export default {
             icon: item.icon,
             image: item.image,
             disabled: item.disabled,
+            uuid: makeId(10),
           }
         } else {
           // if not key/value pair
@@ -238,6 +240,7 @@ export default {
             text: item,
             value: item,
             type: 'item',
+            uuid: makeId(10),
           }
         }
       })
@@ -383,6 +386,7 @@ export default {
 
   .custom-text {
     display: inline-block;
+    pointer-events: none;
   }
 
   // image in list

--- a/src/components/Dropdown.vue
+++ b/src/components/Dropdown.vue
@@ -82,8 +82,8 @@
 <script>
 /* eslint-disable vue/require-prop-types, vue/no-unused-properties */
 import { computed, onMounted, reactive, toRefs } from '@vue/composition-api'
-import { makeId } from '../db/externalID'
 import { parsePxStyle, validateSize } from './mixins'
+import { uid } from '../utils/uid'
 
 export default {
   name: 'Dropdown',
@@ -230,7 +230,7 @@ export default {
             icon: item.icon,
             image: item.image,
             disabled: item.disabled,
-            uuid: makeId(10),
+            uuid: uid(2),
           }
         } else {
           // if not key/value pair
@@ -240,7 +240,7 @@ export default {
             text: item,
             value: item,
             type: 'item',
-            uuid: makeId(10),
+            uuid: uid(2),
           }
         }
       })


### PR DESCRIPTION
### Issue link

no link

### 📖  Description

- Dropdown: use a unique id for list items keys
- fix issue related to blocked click event by a selected text field

- [ ] Tested on Windows
- [ ] Tested on iOS

