### PR TITLE
fix:  read props from layoutitem, add field validati on errors

### DIFF
--- a/src/components/ObjectForm.vue
+++ b/src/components/ObjectForm.vue
@@ -184,11 +184,15 @@ export default {
       needsRecordType: computed(() => {
         return !state.recordTypeId
       }),
+      fieldValidationErrors: [],
       isValid: computed(() => {
         let valid = true
 
+        state.fieldValidationErrors = []
+
         for (const field of state.fields) {
-          if (!field.valid(state.obj[field.name])) {
+          if (!field.valid(state.obj[field.name]) && field.updateable) {
+            state.fieldValidationErrors.push(`${field.label} is mandatory.`)
             valid = false
           }
         }
@@ -346,12 +350,13 @@ export default {
                             field = fieldDict[comp.details.name]
                           } else {
                             field = new Field(comp.details, null, false)
+                            if (item.required === true) field.required = item.required
                             fieldDict[comp.details.name] = field
                             fields.push(field)
                             if (props.customSettings[field.name]) {
                               field.settings = props.customSettings[field.name]
                             }
-                            if (fieldShouldBeReadOnly(field)) {
+                            if (fieldShouldBeReadOnly(field) || item.editableForNew === false || item.editableForUpdate === false) {
                               field.updateable = false
                             }
                             if (props.customReferences && props.customReferences[field.name]) {

--- a/src/db/sfdcField.js
+++ b/src/db/sfdcField.js
@@ -12,7 +12,7 @@ export class Field {
 
     this.parentObjectType = objectType
 
-    this.required = !obj.nillable || obj.nameField
+    this.required = !obj.nillable || obj.nameField || obj.required
 
     if (obj.type === 'picklist') {
       this.filteredValues = obj.picklistValues


### PR DESCRIPTION
### Issue link

 no link

### 📖  Description

- order form - field required and editable props are now also taken from layout item props. 
- order form - store field validation errors 

- [x] Tested on Windows
- [x] Tested on iOS
