### PR TITLE
fix: field should update controlled filed only if not readonly

### DIFF
--- a/src/components/ObjectForm.vue
+++ b/src/components/ObjectForm.vue
@@ -438,7 +438,7 @@ export default {
             field.dependentValueWatcher = watch(
               () => state.obj[field.controllerName],
               (newVal) => {
-                if (state.fieldsDict[field.controllerName]) {
+                if (state.fieldsDict[field.controllerName] && !fieldShouldBeReadOnly(field)) {
                   // When controller field changes - Reset dependent value
                   Vue.set(state.obj, field.name, null)
                   // Find the index of the selected value in the controller field


### PR DESCRIPTION
### Issue link

no link

### 📖  Description

When the OrderFormField got some dependent fields, update them only if those are editable.

- [x] Tested on Windows
- [x] Tested on iOS
