### PR TITLE
fix: emit change when date is cleared with key press

### DIFF
--- a/src/components/Calendar.vue
+++ b/src/components/Calendar.vue
@@ -228,13 +228,19 @@ export default {
           // Starting point of selection
           state.date = date
           state.dateStr = text
+
+          if (!date) emit('input', '')
         },
         onBeforeChange: () => emit('onBeforeChange'),
         onShow: () => emit('onShow'),
         onVisible: () => emit('onVisible'),
         onHide: () => emit('onHide'),
         onHidden: () => emit('onHidden'),
-        onSelect: () => emit('onSelect'),
+        onSelect: (date, mode) => {
+          state.date = date
+          handleInputEmit()
+          emit('onSelect', { date, mode })
+        },
         // merge with settings
         ...props.setting,
       }


### PR DESCRIPTION
### Issue link

no link

### 📖  Description

- adds a fix to case, when date was cleared with 'del' or 'backspace' key. 
- change in onSelect event - emit onSelect with params and emit input date change (case when user click same date as previously selected) 

- [x] Tested on Windows
- [x] Tested on iOS
