### PR TITLE
fix: load more btn visibility fix

### DIFF
--- a/src/components/FilterDropdown.vue
+++ b/src/components/FilterDropdown.vue
@@ -445,7 +445,7 @@ export default {
     }
 
     const showLoadMore = computed(() => {
-      if (props.itemsPerPage && parsedItems.value.length !== state.itemsVisible) {
+      if (props.itemsPerPage && parsedItems.value.length > state.itemsVisible) {
         return true
       }
 


### PR DESCRIPTION
### Issue link
 no url

### 📖  Description

- fixes issue related to visible show more button, even if there is no other items to load.

- [x] Tested on Windows
- [x] Tested on iOS
