### PR TITLE
feat: add generate endpoint (.po only - no translate)

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "bin": {
     "config-gettext-compile": "src/gettext/compile-cli.js",
     "config-gettext-extract": "src/gettext/extract-cli.js",
-    "config-gettext-translate": "src/gettext/translate-cli.js"
+    "config-gettext-translate": "src/gettext/translate-cli.js",
+    "config-gettext-generate": "src/gettext/generate-cli.js"
   },
   "scripts": {
     "build": "rimraf ./dist && babel src -d dist",

--- a/src/gettext/generate-cli.js
+++ b/src/gettext/generate-cli.js
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+const config = require('./config')
+const { translateConfig } = require('./translate')
+
+translateConfig(config, true).catch(console.error)


### PR DESCRIPTION
### Issue link
https://pitcher-ag.atlassian.net/browse/APPS-1118

Check https://github.com/PitcherAG/pitcher-js-platform/pull/100

### 📖  Description

**What is the final goal**

There is the need for using [lokalise](https://lokalise.com/), to generate .po files (with no translation) only from the .pot file. After that the `.po` and the `json` (aka the compiled) files will be merged with the [lokalise](https://lokalise.com/) branches.

**How I tried to achieve it**

I tried to implement this functionality with the minimum changes, using the existing functions and introducing the `onlyGeneratePO` parameter at the `translateConfig` function, keeping the backwards compatibility.

I refactored the `translateFile`, replacing comments with functions (as better practice), and also I wanted the code to be more readable, especially when using the new `onlyGeneratePO` parameter.

### 📷  Screenshots

You can see the generation of `.po` files form the `.pot` file in the following video (using `yarn link "@pitcher/vue-sdk"`)

https://user-images.githubusercontent.com/11004500/144387958-3095de54-ca30-44f6-93b0-0af16507ce47.mov


