### PR TITLE
Fix/user data gathering core/config, INS-42

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -48,7 +48,7 @@ export function useConfigStore() {
 function parseConfigData(data) {
   let result = data
 
-  data.customCaches = Array.isArray(data.customCaches) ? data.customCaches : []
+  result.customCaches = Array.isArray(result.customCaches) ? result.customCaches : []
 
   if (PLATFORM === 'IOS') {
     result.customCaches.push({

--- a/src/config.js
+++ b/src/config.js
@@ -227,9 +227,9 @@ export async function loadConfig(source = 'modal') {
     }
   }
 
-  console.log('[@pitcher/core]: app config', config)
-
   const parsedData = parseConfigData(config)
+
+  console.log('[@pitcher/core]: app config', parsedData)
 
   for (const a in parsedData) {
     store.state[a] = parsedData[a]

--- a/src/config.js
+++ b/src/config.js
@@ -1,7 +1,6 @@
 import { PLATFORM } from './platform'
 import { createStore } from './store'
 import { fireEvent } from './event'
-import { useParams } from './params'
 
 class ConfigStore {
   id = 'config'
@@ -46,42 +45,11 @@ export function useConfigStore() {
   return createStore(new ConfigStore())
 }
 
-export async function loadConfig(source = 'modal') {
-  const store = useConfigStore()
-  let result = await fireEvent('getAppConfig', { source })
+function parseConfigData(data) {
+  let result = data
 
-  if (typeof result.userAttrSpecificSettings !== 'undefined') {
-    const params = useParams()
-    const user = params.user
+  data.customCaches = Array.isArray(data.customCaches) ? data.customCaches : []
 
-    result.userAttrSpecificSettings.forEach((custom) => {
-      const value = user[custom.attrP]
-      const matches = value && value.includes(custom.valueP)
-
-      if (matches) {
-        if (custom.typeP === 'replace') {
-          for (const a in custom.settings) {
-            result[a] = custom.settings[a]
-          }
-        } else if (custom.typeP === 'add') {
-          for (const a in custom.settings) {
-            if (!result[a]) {
-              result[a] = []
-            }
-            if (Array.isArray(custom.settings[a])) {
-              result[a] = result[a].concat(custom.settings[a])
-            } else {
-              result[a].push(custom.settings[a])
-            }
-          }
-        }
-      }
-    })
-  }
-
-  console.log('[@pitcher/core]: app config', result)
-
-  result.customCaches = Array.isArray(result.customCaches) ? result.customCaches : []
   if (PLATFORM === 'IOS') {
     result.customCaches.push({
       objectName: 'Account',
@@ -221,8 +189,50 @@ export async function loadConfig(source = 'modal') {
     throw new Error(`Platform not supported: ${PLATFORM}`)
   }
 
-  for (const a in result) {
-    store.state[a] = result[a]
+  return result
+}
+
+export async function loadConfig(source = 'modal') {
+  const store = useConfigStore()
+  const config = await fireEvent('getAppConfig', { source })
+
+  if (typeof config.userAttrSpecificSettings !== 'undefined') {
+    const sfInfo = await fireEvent('getSFInfo', { source })
+    const user = sfInfo && sfInfo.user ? sfInfo.user : undefined
+
+    if (user) {
+      config.userAttrSpecificSettings.forEach((custom) => {
+        const value = user[custom.attrP]
+        const matches = value && value.includes(custom.valueP)
+
+        if (matches) {
+          if (custom.typeP === 'replace') {
+            for (const a in custom.settings) {
+              config[a] = custom.settings[a]
+            }
+          } else if (custom.typeP === 'add') {
+            for (const a in custom.settings) {
+              if (!config[a]) {
+                config[a] = []
+              }
+              if (Array.isArray(custom.settings[a])) {
+                config[a] = config[a].concat(custom.settings[a])
+              } else {
+                config[a].push(custom.settings[a])
+              }
+            }
+          }
+        }
+      })
+    }
+  }
+
+  console.log('[@pitcher/core]: app config', config)
+
+  const parsedData = parseConfigData(config)
+
+  for (const a in parsedData) {
+    store.state[a] = parsedData[a]
   }
 
   return store.state

--- a/src/params.js
+++ b/src/params.js
@@ -90,8 +90,6 @@ export function useParamsStore() {
 export async function loadParams() {
   const store = useParamsStore()
 
-  console.log(store.state.account)
-
   // for testing
   if (process.env.VUE_APP_PARAMS) {
     const preParams = JSON.parse(process.env.VUE_APP_PARAMS)


### PR DESCRIPTION
### Issue link
No issue link as we detected the issue before it was reported.

### 📖  Description
This pull request makes config load operation much safer.
- Handles the user gathering in config.js via native event, getSFInfo. 
  - If the config includes 'userAttrSpecificSettings', config.js requires CRM user information.
  - Previously, it was gathered via params.user, and params is empty if it is UI. If it is interactive, this still does not make sense as one should load params before config each time, causing all of the interactives having vue-project-template to fail.
- Makes config.js much more readable.
- Handles an unnecessary console.log removal.

- [ x ] Tested on Windows
