### PR TITLE
feat: add `forceCurrencyCode` property to ObjectForm APPS-3654

### DIFF
--- a/src/components/ObjectForm.vue
+++ b/src/components/ObjectForm.vue
@@ -31,6 +31,7 @@
         :valueLabel="toLabel(state.obj, field.name)"
         :field="field"
         :showError="state.showErrors"
+        :forceCurrencyCode="forceCurrencyCode"
         :hideHelpText="hideHelpText"
         @input="emitUpdate"
         @fieldChange="(v) => $emit('fieldChange', v)"
@@ -50,6 +51,7 @@
                   :key="compKey"
                   v-model="state.obj[comp.value]"
                   :valueLabel="toLabel(state.obj, comp.value, comp.field)"
+                  :forceCurrencyCode="forceCurrencyCode"
                   :field="comp.field"
                   :showError="state.showErrors"
                   :hideHelpText="hideHelpText"
@@ -94,6 +96,10 @@ export default {
     excludeFields: {
       default: () => [],
       type: Array,
+    },
+    forceCurrencyCode: {
+      default: '',
+      type: String,
     },
     readOnlyFields: {
       default: () => [],

--- a/src/components/ObjectFormField.vue
+++ b/src/components/ObjectFormField.vue
@@ -95,7 +95,7 @@
           </template>
           <!-- Currency -->
           <template v-else-if="field.type === 'currency'">
-            {{ formatCurrency(value) }}
+            {{ formatCurrency(value, forceCurrencyCode) }}
           </template>
           <!-- Date -->
           <template v-else-if="field.type === 'date' || field.type === 'datetime'">
@@ -132,6 +132,10 @@ export default {
     field: {
       type: Object,
       required: true,
+    },
+    forceCurrencyCode: {
+      default: '',
+      type: String,
     },
     index: {
       type: Number,
@@ -214,7 +218,14 @@ export default {
       }
     }
 
-    return { filteredValues, emitInput, error, formatDate, formatCurrency, getReferenceName }
+    return {
+      filteredValues,
+      emitInput,
+      error,
+      formatDate,
+      formatCurrency,
+      getReferenceName,
+    }
   },
 }
 </script>


### PR DESCRIPTION
Add property to both ObjectForm and ObjectFormField in order to be able
to call formatCurrency with a second argument (currency)

### Issue link
https://pitcher-ag.atlassian.net/browse/APPS-3654

### 📖  Description
This pull request adds a new property to ObjectForm and ObjectFormField. The new property is called `forceCurrencyCode` and its purpose is to get all the way to where `formatCurrency` is called (formatCurrency is called when a field of type "currency" exist. Before the fix, formatCurrency was called with just one argument (value) resulting in error when loading an Object wo/ an account (no active call)

- [x] Tested on Windows

### 📷  Screenshots
