### PR TITLE
feat: add 'disabled' html attribute to NumpadInput APPS-4470

### DIFF
--- a/src/components/NumpadInput.vue
+++ b/src/components/NumpadInput.vue
@@ -9,6 +9,7 @@
         ref="input"
         :value="localValue"
         type="text"
+        :disabled="inputAttrs.class.disabled ? true : false"
         readonly="readonly"
         class="number-input"
         :style="inputAttrs.style"
@@ -493,7 +494,9 @@ $border-radius: 8.4px;
 
     input {
       text-align: right;
-
+      &:disabled {
+        opacity: 1;
+      }
       &:active,
       &:visited {
         border-color: #85b7d9;


### PR DESCRIPTION
- prevent user actions in disabled input fields
- add css rule to not apply double opacity rule (one on the div and one on the input)

### Issue link
https://pitcher-ag.atlassian.net/browse/APPS-4470

### 📖  Description
This pull request adds the 'disabled' html attribute to the input element of the NumpadInput component

Previously, user could navigate to a "disabled" (actually read-only) input element, using the keypad's "next" button, and enter a value 

- [x] Tested on Windows

### 📷  Screenshots

https://user-images.githubusercontent.com/5673119/173572857-ce357388-c9f0-4e34-8e3d-ba3e712753cd.mov