### PR TITLE
feat: data-table add option to allow case insensitive sorting APPS-4663

### DIFF
--- a/src/components/DataTable/DataTable.vue
+++ b/src/components/DataTable/DataTable.vue
@@ -220,6 +220,7 @@ export default defineComponent({
         useExtendedSearch: true,
       }),
     },
+    sortOptions: Array,
     trClass: {
       type: [String, Function],
       default: undefined,
@@ -339,7 +340,7 @@ export default defineComponent({
 
       // sort
       if (state.sort.by) {
-        temp = sortBy(temp, props.fields, state.sort.by, state.sort.order)
+        temp = sortBy(temp, props.fields, state.sort.by, state.sort.order, props.sortOptions)
       }
 
       // pagination active & paginate

--- a/src/components/DataTable/table.helpers.js
+++ b/src/components/DataTable/table.helpers.js
@@ -1,3 +1,4 @@
+import get from 'lodash/get'
 import orderBy from 'lodash/orderBy'
 import { renderContext } from '../../utils'
 
@@ -18,7 +19,7 @@ export function mapper(key, obj) {
   return obj[key]
 }
 
-export function sortBy(data, fields, by, order) {
+export function sortBy(data, fields, by, order, sortOptions) {
   const field = fields.find((f) => f.dataField === by)
 
   if (!field) {
@@ -27,7 +28,11 @@ export function sortBy(data, fields, by, order) {
 
   if (typeof field.sortType === 'undefined' || field.sortType === 'string') {
     // sortType: string or sortType: undefined
-    return orderBy(data, [by], [order])
+    const fieldWithSortingOptions = sortOptions && sortOptions.find((i) => i.fieldName === by)
+
+    if (fieldWithSortingOptions && fieldWithSortingOptions.ignoreCase)
+      return orderBy(data, [(item) => get(item, by).toLowerCase()], [order])
+    else return orderBy(data, [by], [order])
   } else if (field.sortType === 'number') {
     // sortType: number
     return orderBy(


### PR DESCRIPTION
### Issue link

https://pitcher-ag.atlassian.net/browse/APPS-4663

### 📖  Description

This pull request adds the option to sort some fields using a case-insensitive approach

Sample Usage:

```
<DataTable
  ...
  :sortOptions="[{ fieldName: 'product.Name', ignoreCase: true }]"
  ...
>
...
</DataTable>
```

- [x] Tested on Windows
