### PR TITLE
feat: emit `focus` and `blur` events from `NumpadInput` APPS-4749

### DIFF
--- a/src/components/NumpadInput.vue
+++ b/src/components/NumpadInput.vue
@@ -14,8 +14,14 @@
         class="number-input"
         :style="inputAttrs.style"
         :placeholder="placeholder"
-        @focus="focus(true)"
-        @blur="focus(false)"
+        @focus="() => {
+          $emit('focus')
+          return focus(true)
+        }"
+        @blur="() => {
+          $emit('blur')
+          return focus(false)
+        }"
         @keypress.prevent
         @keydown.prevent="handleKeydown"
         @touchstart.stop
@@ -167,7 +173,7 @@ export default defineComponent({
       default: false,
     },
   },
-  emits: ['input'],
+  emits: ['input', 'focus', 'blur'],
   setup(props, ctx) {
     const localState = reactive({
       numpadIsVisible: false,


### PR DESCRIPTION
### Issue link
https://pitcher-ag.atlassian.net/browse/APPS-4749

### 📖  Description
This pull request:
- adds event emission on `focus` and `blur` of the text input inside `NumpadInput`

- [x] Tested on Windows

### 📷  Screenshots
![Screenshot 2022-07-15 at 10 42 42](https://user-images.githubusercontent.com/11925511/179176600-c60aa520-1c9c-4517-ab32-a175215016d4.png)

