### PR TITLE
wip: use alternatively main JSON files for translations with a param

### DIFF
--- a/src/i18n/i18n.js
+++ b/src/i18n/i18n.js
@@ -18,22 +18,37 @@ const defaultOptions = {
 class I18nStore {
   id = 'i18n'
   state = defaultOptions
-  async setLanguage(lang, { app = 'app', dir = 'translations', load = true } = {}) {
+  async setLanguage(lang, { app = 'app', dir = 'translations', load = true, useDefaultJSON = false } = {}) {
     if (!this.state.availableLanguages[lang]) {
       throw new Error(`invalid language: ${lang}`)
     }
 
     if (load && lang !== 'en') {
-      const response = await fetch(`${dir}/${lang}/${app}.json`)
-      const data = await response.json()
+      if (useDefaultJSON) {
+        const response = await fetch(`../lang/${lang.toUpperCase()}.json`)
+        const data = await response.json()
 
-      for (const locale in data) {
-        if (this.state.messages[locale]) {
-          for (const msgid in data[locale]) {
-            this.state.messages[locale][msgid] = data[locale][msgid]
+        for (const locale in data) {
+          if (this.state.messages[locale]) {
+            for (const msgid in data) {
+              this.state.messages[locale][msgid] = data[msgid]
+            }
+          } else {
+            this.state.messages[locale] = data
           }
-        } else {
-          this.state.messages[locale] = data[locale]
+        }
+      } else {
+        const response = await fetch(`${dir}/${lang}/${app}.json`)
+        const data = await response.json()
+
+        for (const locale in data) {
+          if (this.state.messages[locale]) {
+            for (const msgid in data[locale]) {
+              this.state.messages[locale][msgid] = data[locale][msgid]
+            }
+          } else {
+            this.state.messages[locale] = data[locale]
+          }
         }
       }
     }


### PR DESCRIPTION
### Issue link
https://pitcher-ag.atlassian.net/browse/DAN-1204


### 📖  Description
This pull request aims to use alternatively main JSON files (in the lang folder) for translations

I could not make the repo work on my local yet. It's a wip PR, we can have a look at it together. The main idea for this is that we are using lokalise with one project. And it is easier to maintain like that. And also, we are adding some extra codes to make it work. So this PR can make it easier only with

`await i18n.setLanguage(locale, { useDefaultJSON: true })`


`ref` https://github.com/PitcherAG/danone/pull/311/files


cc: @veliozguryildiz 

- [ ] Tested on Windows

### 📷  Screenshots
